### PR TITLE
Pass the mapping index to moveAll callback

### DIFF
--- a/src/Multipart/FileJar.js
+++ b/src/Multipart/FileJar.js
@@ -106,8 +106,8 @@ class FileJar {
    */
   moveAll (location, callback) {
     callback = typeof (callback) === 'function' ? callback : function () {}
-    return Promise.all(_.map(this._files, (file) => {
-      return file.move(location, callback(file))
+    return Promise.all(_.map(this._files, (file, index) => {
+      return file.move(location, callback(file, index))
     }))
   }
 


### PR DESCRIPTION
To avoid naming collisions

profilePics.moveAll(Helpers.tmpPath('uploads'), (file, index) => {
  return {
    name: `${new Date().getTime()}-${index}.${file.subtype}`
  }
})