### PR TITLE
Pass the overwrite option to fs.move inside move()

### DIFF
--- a/src/Multipart/File.js
+++ b/src/Multipart/File.js
@@ -447,7 +447,7 @@ class File {
      * Otherwise move the tmpFile to the user specified
      * location.
      */
-    await fs.move(this.tmpPath, path.join(location, options.name), { overwrite: options.overwrite })
+    await fs.move(this.tmpPath, path.join(location, options.name), { overwrite: !!options.overwrite })
     this.fileName = options.name
     this._location = location
     this.status = 'moved'

--- a/src/Multipart/File.js
+++ b/src/Multipart/File.js
@@ -447,7 +447,7 @@ class File {
      * Otherwise move the tmpFile to the user specified
      * location.
      */
-    await fs.move(this.tmpPath, path.join(location, options.name))
+    await fs.move(this.tmpPath, path.join(location, options.name), { overwrite: options.overwrite })
     this.fileName = options.name
     this._location = location
     this.status = 'moved'


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

As `File.js` uses `fs-extra`, an error is thrown if we try to overwrite a file. That happens because the `fs.move()` default value to `overwrite` is `false`.

Now you can simply pass along your options `overwrite: true` to make sure that the file will be overwritten.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-bodyparser/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
