### PR TITLE
Typo fix and writing style touch-up

### DIFF
--- a/config/bodyParser.js
+++ b/config/bodyParser.js
@@ -27,8 +27,8 @@ module.exports = {
     | strict
     |--------------------------------------------------------------------------
     |
-    | When `scrict` is set to true, body parser will only parse Arrays and
-    | Object. Otherwise everything parseable by `JSON.parse` is parsed.
+    | When `strict` is set to true, body parser will only parse Arrays and
+    | Object. Otherwise everything parsable by `JSON.parse` is parsed.
     |
     */
     strict: true,
@@ -39,7 +39,7 @@ module.exports = {
     |--------------------------------------------------------------------------
     |
     | Which content types are processed as JSON payloads. You are free to
-    | add your own types here, but the request body should be parseable
+    | add your own types here, but the request body should be parsable
     | by `JSON.parse` method.
     |
     */
@@ -119,7 +119,7 @@ module.exports = {
     | manually process the files when required.
     |
     | This value can contain a boolean or an array of route patterns
-    | to be autoprocessed.
+    | to be auto-processed.
     */
     autoProcess: true,
 
@@ -143,7 +143,7 @@ module.exports = {
     | Define a function, which should return a string to be used as the
     | tmp file name.
     |
-    | If not defined, Bodyparser will use `uuid` as the tmp file name.
+    | If not defined, BodyParser will use `uuid` as the tmp file name.
     |
     | To be defined as. If you are defining the function, then do make sure
     | to return a value from it.


### PR DESCRIPTION
## Proposed changes

Documentation update - fixed one typo, and ensured that the spelling of BodyParser matches the one in README, also a couple of style touch-ups.
Changed "parseable" to "parsable", as https://en.wiktionary.org/wiki/parseable favors the latter for formal writing.

## Types of changes

- [x] Documentation fix
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-bodyparser/blob/master/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)

NB: No test-breaking changes were made
NB2: Link referred from CONTRIBUTING https://github.com/adonisjs/adonis-bodyparser/blob/develop/CONTRIBUTING.md leads to 404 page.
